### PR TITLE
Replace `numpy.alltrue` with `numpy.all`

### DIFF
--- a/releasenotes/notes/replace-numpy-alltrue-a6fbe0478678c9b7.yaml
+++ b/releasenotes/notes/replace-numpy-alltrue-a6fbe0478678c9b7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Replaced usage of `numpy.alltrue` with `numpy.all` throughout the codebase, 
+    to be specific in: `test/test_fermion_circuit_solver.py`, `test/test_spin_circuit_solver.py`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.17
 scipy>=1.4
 requests>=2.25.1
 qiskit-terra>= 0.17.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.17
+numpy
 scipy>=1.4
 requests>=2.25.1
 qiskit-terra>= 0.17.1

--- a/test/test_fermion_circuit_solver.py
+++ b/test/test_fermion_circuit_solver.py
@@ -63,7 +63,7 @@ class TestFermionCircuitSolver(QiskitTestCase):
         self.solver2.preprocess_circuit(circ)
         init_state = self.solver2.get_initial_state(circ)
         target = np.array([0, 0, 1, 0])
-        self.assertTrue(np.alltrue(init_state.toarray().T == target))
+        self.assertTrue(np.all(init_state.toarray().T == target))
 
     def test_embed_operator(self):
         """test embedding of an operator"""
@@ -149,7 +149,7 @@ class TestFermionCircuitSolver(QiskitTestCase):
                 ]
             )
             test_op = self.solver2.operator_to_mat(Hop(num_modes=4, j=[0.5]).generator)
-            self.assertTrue(np.alltrue(test_op.toarray() == target))
+            self.assertTrue(np.all(test_op.toarray() == target))
 
     def test_draw_shots(self):
         """test drawing of the shots from a measurement distribution"""
@@ -171,7 +171,6 @@ class TestFermionCircuitSolver(QiskitTestCase):
                 self.solver2.draw_shots(np.ones(3) / 3)
 
         with self.subTest("formatting of measurement outcomes"):
-
             self.solver2.seed = 40
             outcomes = self.solver2.draw_shots(np.ones(4) / 4)
             self.assertEqual(outcomes, ["0110", "0101", "1010", "0110", "0110"])

--- a/test/test_spin_circuit_solver.py
+++ b/test/test_spin_circuit_solver.py
@@ -39,7 +39,7 @@ class TestSpinCircuitSolver(QiskitTestCase):
         circ = QuantumCircuit(1)
         init_state = self.solver.get_initial_state(circ)
         target = np.array([1, 0, 0, 0])
-        self.assertTrue(np.alltrue(init_state.toarray().T == target))
+        self.assertTrue(np.all(init_state.toarray().T == target))
 
     def test_embed_operator(self):
         """test embedding of an operator"""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This pull request addresses issue #75  related to the deprecation of `alltrue` in favor of `all` in numpy versions 1.25 and later. The tests in Qiskit Cold Atoms were failing when run with versions >= 1.25.

### Changes:

Replaced usages of `numpy.alltrue` with `numpy.all` throughout the codebase, to be specific in:

- `test/test_fermion_circuit_solver.py`
- `test/test_spin_circuit_solver.py`


