### PR TITLE
Remove gh-pages from docs Makefile

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,15 +22,6 @@ help:
 
 .PHONY: help Makefile
 
-.PHONY: gh-pages
-.ONESHELL:
-gh-pages:
-	rm -rf /tmp/gh-pages
-	cp -r $(BUILDDIR)/html /tmp/gh-pages
-	git checkout gh-pages
-	cd .. && rm -rf * && cp -r /tmp/gh-pages/* ./ && rm -rf /tmp/gh-pages && git add . && git commit -m "Updated gh-pages" && git push && git checkout main
-
-
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Despite the docs content and makefile having migrated from the `gh-pages` branch to the `docs` directory in `main` a while ago, the github pages workflow was still set up to pull the documentation from `gh-pages`. For this reason, the docs updates were failing to show up in the page. 

After changing the settings to pull the content from `main`, the https://qiskit-community.github.io/qiskit-cold-atom/ link broke down, and I believe it could be because of a couple of lines in the makefile that still refer to the `gh-pages` branch. This PR is an attempt to fix the workflow and restore the documentation link. 

### Details and comments


