### PR TITLE
Move methods into class pages for docs

### DIFF
--- a/docs/_templates/autosummary/class.rst
+++ b/docs/_templates/autosummary/class.rst
@@ -8,20 +8,17 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
+   :show-inheritance:
    :no-members:
    :no-inherited-members:
    :no-special-members:
 
    {% block attributes_summary %}
    {% if attributes %}
-
    .. rubric:: Attributes
-
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_attributes %}
       {%- if not item.startswith('_') %}
-      {{ name }}.{{ item }}
+   .. autoattribute:: {{ name }}.{{ item }}
       {%- endif -%}
    {%- endfor %}
    {% endif %}
@@ -29,19 +26,17 @@
 
    {% block methods_summary %}
    {% if methods %}
-
    .. rubric:: Methods
-
-   .. autosummary::
-      :toctree: ../stubs/
    {% for item in all_methods %}
-      {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-      {{ name }}.{{ item }}
+      {%- if item not in inherited_members %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
+   .. automethod:: {{ name }}.{{ item }}
+         {%- endif -%}
       {%- endif -%}
    {%- endfor %}
    {% for item in inherited_members %}
       {%- if item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-      {{ name }}.{{ item }}
+   .. automethod:: {{ name }}.{{ item }}
       {%- endif -%}
    {%- endfor %}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Moved all the methods and attributes into class pages to speed up the building process of the documentation with the new ecosystem sphinx theme. This change helps with this [PR](https://github.com/qiskit-community/qiskit-cold-atom/pull/78).

See https://github.com/Qiskit/qiskit/pull/10455 for more information.