### PR TITLE
Fix templates documentation

### DIFF
--- a/docs/_templates/autosummary/class_no_inherited_members.rst
+++ b/docs/_templates/autosummary/class_no_inherited_members.rst
@@ -1,3 +1,5 @@
+{# This is identical to class.rst, except for the filtering of the inherited_members. -#}
+
 {% if referencefile %}
 .. include:: {{ referencefile }}
 {% endif %}
@@ -28,8 +30,10 @@
    {% if methods %}
    .. rubric:: Methods
    {% for item in all_methods %}
-      {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
+      {%- if item not in inherited_members %}
+         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
    .. automethod:: {{ name }}.{{ item }}
+         {%- endif -%}
       {%- endif -%}
    {%- endfor %}
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
This PR creates another template for the classes without inherited members simplifying the `class.rst` template file.

Also, In the original `class.rst`, we have two consecutive for, one for all methods, and another one for only the inherited_members. With this two for, we are duplicating the entries of the inherited methods (they appear two times in the page). In a previous [pull request](https://github.com/qiskit-community/qiskit-cold-atom/pull/83), I added an extra if but that removed the inherit_members that we had before. This PR fixes that problem.